### PR TITLE
Fix long filenames in archives

### DIFF
--- a/bfd/archive.c
+++ b/bfd/archive.c
@@ -1754,8 +1754,8 @@ _bfd_write_archive_contents (arch)
     {
       struct ar_hdr hdr;
 
-      memset ((char *) (&hdr), 0, sizeof (struct ar_hdr));
-      strcpy (hdr.ar_name, ename);
+      memset (&hdr, ' ', sizeof (struct ar_hdr));
+      memcpy (hdr.ar_name, ename, strlen (ename));
       /* Round size up to even number in archive header.  */
       _bfd_ar_spacepad (hdr.ar_size, sizeof (hdr.ar_size), "%-10ld",
                         (elength + 1) & ~(bfd_size_type) 1);


### PR DESCRIPTION
Two lines were omitted in the initial backport of the "spacepad" patch
[1] in commit b8fa24d6f7fa7f5216e988aa2416901c88a5870f. Without these,
ar creates broken archives when extended file names are used.

---
$ echo "test: rts" | m68k-amigaos-as -o a_long_filename.o -
$ m68k-amigaos-ar rc archive.a a_long_filename.o
$ m68k-amigaos-ar t archive.a
ARFILENAMES/

$
---
(The special element name ARFILENAMES/ is not recognized because of the
missing padding).

[1] Upstream commit 390c0e4288ca46982c7702ec420d277c021032f4,
https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commitdiff;h=390c0e4288ca46982c7702ec420d277c021032f4